### PR TITLE
Add wrapped headers + base.clock()

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,10 @@ const base = new Autobase([inputA, inputB, inputC], { input: inputA })
 // Add a few messages to the local writer.
 // These messages will contain the Autobase's latest vector clock by default.
 await base.append('hello')
-await base.append('world')
+
+// You can also append through the `base.local` property.
+// `base.local` is a Hypercore session with a custom valueEncoding that includes the latest Autobase clocks.
+await base.local.append('world')
 
 // Create a linearized "index" Hypercore with causal ordering. `output` is a Hypercore.
 // When index.update is called, the inputs will be automatically rebased into the index.
@@ -57,7 +60,7 @@ Options include:
 
 ```js
 {
-  defaultInput: null,  // A default Hypercore to append to
+  input: null,         // A default Hypercore to append to
   indexes: null,       // A list of rebased index Hypercores
   autocommit: true     // Automatically persist changes to rebased indexes after updates
 }
@@ -68,6 +71,21 @@ The list of input Hypercores.
 
 #### `base.defaultIndexes`
 The list of default rebased indexes.
+
+#### `base.local`
+If the Autobase is initialized with a writable Hypercore, `base.local` will be a Hypercore session with a special `valueEncoding` that wraps appended values with the latest Autobase clock.
+
+This is mostly useful for ergonomics, as `base.local` is "just a Hypercore":
+
+```js
+// These are equivalent
+const base = new Autobase([inputA])
+await base.local.append('hello')
+await base.append('hello', await base.latest(), inputA)
+```
+
+#### `await Autobase.isAutobase(core)`
+Returns `true` if `core` is either an Autobase input or a rebased index.
 
 #### `await base.append(value, [clock], [input])`
 Append a new value to the autobase.

--- a/README.md
+++ b/README.md
@@ -31,10 +31,7 @@ const base = new Autobase([inputA, inputB, inputC], { input: inputA })
 // Add a few messages to the local writer.
 // These messages will contain the Autobase's latest vector clock by default.
 await base.append('hello')
-
-// You can also append through the `base.local` property.
-// `base.local` is a Hypercore session with a custom valueEncoding that includes the latest Autobase clocks.
-await base.local.append('world')
+await base.append('world')
 
 // Create a linearized "index" Hypercore with causal ordering. `output` is a Hypercore.
 // When index.update is called, the inputs will be automatically rebased into the index.
@@ -72,17 +69,8 @@ The list of input Hypercores.
 #### `base.defaultIndexes`
 The list of default rebased indexes.
 
-#### `base.local`
-If the Autobase is initialized with a writable Hypercore, `base.local` will be a Hypercore session with a special `valueEncoding` that wraps appended values with the latest Autobase clock.
-
-This is mostly useful for ergonomics, as `base.local` is "just a Hypercore":
-
-```js
-// These are equivalent
-const base = new Autobase([inputA])
-await base.local.append('hello')
-await base.append('hello', await base.latest(), inputA)
-```
+#### `base.clock`
+A Map containing the latest lengths for all Autobase inputs.
 
 #### `await Autobase.isAutobase(core)`
 Returns `true` if `core` is either an Autobase input or a rebased index.

--- a/index.js
+++ b/index.js
@@ -5,6 +5,8 @@ const debounce = require('debounceify')
 const RebasedHypercore = require('./lib/rebase')
 const { InputNode, IndexNode } = require('./lib/nodes')
 
+const INPUT_PROTOCOL = '@autobase/input/v1'
+
 module.exports = class Autobase {
   constructor (inputs, opts = {}) {
     this.inputs = null
@@ -81,9 +83,12 @@ module.exports = class Autobase {
       const batchOffset = (batch.length !== 1) ? [i, batch.length - 1 - i] : null
       const node = { key: input.key, value: batch[i], batch: batchOffset }
       if (i === batch.length - 1) node.clock = clock
-      nodes.push(InputNode.encode(node))
+      nodes.push(node)
     }
-    return nodes
+    if (input.length === 0) {
+      nodes[0].header = { protocol: INPUT_PROTOCOL }
+    }
+    return nodes.map(InputNode.encode)
   }
 
   _createWriter (input) {

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -1,6 +1,6 @@
 const cenc = require('compact-encoding')
 const {
-  CausalNode: CausalNodeSchema,
+  InputNode: InputNodeSchema,
   IndexNode: IndexNodeSchema
 } = require('./messages')
 
@@ -42,13 +42,13 @@ class InputNode {
       // Remove any self-links, since they are implicit.
       node.clock.delete(node.id)
     }
-    return cenc.encode(CausalNodeSchema, node)
+    return cenc.encode(InputNodeSchema, node)
   }
 
   static decode (raw, from = {}) {
     if (!raw) return null
     try {
-      const decoded = cenc.decode(CausalNodeSchema, raw)
+      const decoded = cenc.decode(InputNodeSchema, raw)
       const node = new this({ ...decoded, key: from.key, seq: from.seq })
       // Add a self-link to the previous node in the input (if it isn't the first node).
       if (node.seq > 0) node.clock.set(node.id, node.seq - 1)
@@ -59,26 +59,6 @@ class InputNode {
     }
   }
 }
-
-/*
- * (writerA):  ('hello', clock1, batch1)
- *          -> ('world', clock1, batch1)
- *          -> ('goodbye', clock1, batch1)
- */
-
-/*
-
-CausalNode { // A writer's view of the system
-  clock,
-  value,
-  batch
-}
-
-IndexNode {
-  change: key, // Pointer to latest batch node
-  node: CausalNode // An indexer's global view of the system
-}
-*/
 
 class IndexNode {
   constructor ({ header, change, clock, value, batch }) {

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -50,7 +50,7 @@ class InputNode {
       const decoded = cenc.decode(CausalNodeSchema, raw)
       const node = new this({ ...decoded, key: from.key, seq: from.seq })
       // Add a self-link to the previous node in the input (if it isn't the first node).
-      if (node.seq > 1) node.clock.set(node.id, node.seq - 1)
+      if (node.seq > 0) node.clock.set(node.id, node.seq - 1)
       return node
     } catch (err) {
       // Gracefully discard malformed messages.

--- a/lib/nodes/index.js
+++ b/lib/nodes/index.js
@@ -5,7 +5,8 @@ const {
 } = require('./messages')
 
 class InputNode {
-  constructor ({ key, seq, value, clock, batch }) {
+  constructor ({ header, key, seq, value, clock, batch }) {
+    this.header = header
     this.key = (key && !Buffer.isBuffer(key)) ? Buffer.from(key, 'hex') : key
     this.value = (value && !Buffer.isBuffer(value)) ? Buffer.from(value) : value
     this.batch = batch || [0, 0]
@@ -80,7 +81,8 @@ IndexNode {
 */
 
 class IndexNode {
-  constructor ({ change, clock, value, batch }) {
+  constructor ({ header, change, clock, value, batch }) {
+    this.header = header
     this.id = change.toString('hex')
     this.seq = clock.get(this.id)
     this.change = change

--- a/lib/nodes/messages.js
+++ b/lib/nodes/messages.js
@@ -1,5 +1,19 @@
 const c = require('compact-encoding')
 
+const Header = {
+  preencode (state, req) {
+    c.string.preencode(state, req.protocol)
+  },
+  encode (state, req) {
+    c.string.encode(state, req.protocol)
+  },
+  decode (state) {
+    return {
+      protocol: c.string.decode(state)
+    }
+  }
+}
+
 // Common Structs
 const Clock = {
   preencode (state, req) {
@@ -61,17 +75,31 @@ const Batch = {
 
 const CausalNode = {
   preencode (state, req) {
+    state.end++ // flags
+    if (req.header) Header.preencode(state, req.header)
     Clocks.preencode(state, req.clock)
     c.buffer.preencode(state, req.value)
     Batch.preencode(state, req.batch)
   },
   encode (state, req) {
+    const s = state.start++
+    let flags = 0
+
+    if (req.header) {
+      flags |= 1
+      Header.encode(state, req.header)
+    }
+
     Clocks.encode(state, req.clock)
     c.buffer.encode(state, req.value)
     Batch.encode(state, req.batch)
+
+    state.buffer[s] = flags
   },
   decode (state) {
+    const flags = c.uint.decode(state)
     return {
+      header: (flags & 1) === 0 ? null : Header.decode(state),
       clock: Clocks.decode(state),
       value: c.buffer.decode(state),
       batch: Batch.decode(state)

--- a/lib/nodes/messages.js
+++ b/lib/nodes/messages.js
@@ -1,13 +1,22 @@
 const c = require('compact-encoding')
 
-const Header = {
+const NodeHeader = {
   preencode (state, req) {
+    state.end++ // flags
+    if (!req) return
     c.string.preencode(state, req.protocol)
   },
   encode (state, req) {
+    if (!req) {
+      c.uint.encode(state, 0)
+      return
+    }
+    c.uint.encode(state, 1)
     c.string.encode(state, req.protocol)
   },
   decode (state) {
+    const flags = c.uint.decode(state)
+    if (!flags) return null
     return {
       protocol: c.string.decode(state)
     }
@@ -73,33 +82,19 @@ const Batch = {
   }
 }
 
-const CausalNode = {
+const CausalInfo = {
   preencode (state, req) {
-    state.end++ // flags
-    if (req.header) Header.preencode(state, req.header)
     Clocks.preencode(state, req.clock)
     c.buffer.preencode(state, req.value)
     Batch.preencode(state, req.batch)
   },
   encode (state, req) {
-    const s = state.start++
-    let flags = 0
-
-    if (req.header) {
-      flags |= 1
-      Header.encode(state, req.header)
-    }
-
     Clocks.encode(state, req.clock)
     c.buffer.encode(state, req.value)
     Batch.encode(state, req.batch)
-
-    state.buffer[s] = flags
   },
   decode (state) {
-    const flags = c.uint.decode(state)
     return {
-      header: (flags & 1) === 0 ? null : Header.decode(state),
       clock: Clocks.decode(state),
       value: c.buffer.decode(state),
       batch: Batch.decode(state)
@@ -107,21 +102,43 @@ const CausalNode = {
   }
 }
 
-// Output Structs
+// Input Schemas
 
-const IndexNode = {
+const InputNode = {
   preencode (state, req) {
-    c.fixed32.preencode(state, req.change)
-    CausalNode.preencode(state, req)
+    NodeHeader.preencode(state, req.header)
+    CausalInfo.preencode(state, req)
   },
   encode (state, req) {
-    c.fixed32.encode(state, req.change)
-    CausalNode.encode(state, req)
+    NodeHeader.encode(state, req.header)
+    CausalInfo.encode(state, req)
   },
   decode (state) {
     return {
+      header: NodeHeader.decode(state),
+      ...CausalInfo.decode(state)
+    }
+  }
+}
+
+// Output Schemas
+
+const IndexNode = {
+  preencode (state, req) {
+    NodeHeader.preencode(state, req.header)
+    c.fixed32.preencode(state, req.change)
+    CausalInfo.preencode(state, req)
+  },
+  encode (state, req) {
+    NodeHeader.encode(state, req.header)
+    c.fixed32.encode(state, req.change)
+    CausalInfo.encode(state, req)
+  },
+  decode (state) {
+    return {
+      header: NodeHeader.decode(state),
       change: c.fixed32.decode(state),
-      ...CausalNode.decode(state)
+      ...CausalInfo.decode(state)
     }
   }
 }
@@ -150,6 +167,7 @@ function compareKeys (a, b) {
 }
 
 module.exports = {
-  CausalNode,
+  NodeHeader,
+  InputNode,
   IndexNode
 }

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -25,7 +25,7 @@ class Rebaser {
   }
 
   async update (node, latestClock) {
-    if (this.baseLength <= 1) {
+    if (this.baseLength < 1) {
       this.added++
       this.changes.push(node)
       return false
@@ -36,7 +36,7 @@ class Rebaser {
       return true
     }
 
-    while (head && !node.eq(head) && (head.contains(node) || !latestClock.get(head.id))) {
+    while (head && !node.eq(head) && (head.contains(node) || !latestClock.has(head.id))) {
       this.removed++
       head = await this._head()
     }
@@ -187,18 +187,6 @@ module.exports = class RebasedHypercore {
     if (this._autocommit) return this.commit()
   }
 
-  // TODO: Do we need to reset the clock to the latest batch clock?
-  // Answer: Clocks are not deduped inside batches right now -- if they were, we gotta inflate
-  /*
-  async _inflate (block, seq) {
-    if (!block.batch[1]) return block
-    const batchEnd = await this._get(seq + block.batch[1])
-    block.seq = batchEnd.seq
-    block.clock = batchEnd.clock
-    return block
-  }
-  */
-
   async _get (seq, opts) {
     return (seq < this._bestIndexLength)
       ? IndexNode.decode(await this._bestIndex.get(seq, { ...opts, valueEncoding: null }))
@@ -210,7 +198,6 @@ module.exports = class RebasedHypercore {
     if (!this._bestIndex) await this.update(opts)
 
     let block = await this._get(seq, opts)
-    // await this._inflate(block, seq)
 
     // TODO: support OOB gets
     if (!block) throw new Error('Out of bounds gets are currently not supported')

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -1,12 +1,10 @@
-const cenc = require('compact-encoding')
 const debounce = require('debounceify')
 const safetyCatch = require('safety-catch')
 
-const { Header } = require('./messages')
 const { IndexNode } = require('./nodes')
 
 const promises = Symbol.for('hypercore.promises')
-const INDEX_TYPE = '@autobase/index'
+const INDEX_PROTOCOL = '@autobase/index/v1'
 
 class Rebaser {
   constructor (index) {
@@ -19,13 +17,13 @@ class Rebaser {
 
   async _head () {
     const length = this.baseLength - this.removed
-    const node = length > 1 ? await this.index.get(length - 1) : null
+    const node = length > 0 ? await this.index.get(length - 1) : null
     if (Buffer.isBuffer(node)) return IndexNode.decode(node)
     return node
   }
 
   async update (node, latestClock) {
-    if (this.baseLength < 1) {
+    if (this.baseLength === 0) {
       this.added++
       this.changes.push(node)
       return false
@@ -55,6 +53,7 @@ module.exports = class RebasedHypercore {
     this[promises] = true
     this.autobase = autobase
     this.indexes = null
+    this.writable = false
 
     this._indexes = indexes
     this._apply = opts.apply || defaultApply
@@ -62,12 +61,12 @@ module.exports = class RebasedHypercore {
     this._autocommit = opts.autocommit
     this._applying = null
 
-    this.update = debounce(this._update.bind(this))
-
     this._bestIndex = null
     this._bestIndexLength = 0
     this._lastRebaser = null
     this._changes = []
+
+    this.update = debounce(this._update.bind(this))
 
     this.opened = false
     this._opening = null
@@ -103,21 +102,12 @@ module.exports = class RebasedHypercore {
       if (index.writable && this._autocommit !== false) {
         this.indexes = [index] // If you pass in a writable index, remote ones are ignored.
         this._autocommit = true
+        this.writable = true
         break
       }
     }
 
     if (this._autocommit === undefined) this._autocommit = false
-
-    if (this._autocommit && this.indexes[0].length === 0) {
-      await this.indexes[0].append(cenc.encode(Header, {
-        protocol: INDEX_TYPE
-      }))
-    } else if (!this.indexes.length) {
-      this._changes.push(cenc.encode(Header, {
-        protocol: INDEX_TYPE
-      }))
-    }
 
     for (const index of this.indexes) {
       if (!this._bestIndex || this._bestIndexLength < index.length) {
@@ -236,6 +226,10 @@ module.exports = class RebasedHypercore {
     if (this._bestIndexLength < this._bestIndex.length) {
       await this._bestIndex.truncate(this._bestIndex.length - this._lastRebaser.removed)
     }
+    if (this._bestIndex.length === 0 && this._changes.length) {
+      this._changes[0].header = { protocol: INDEX_PROTOCOL }
+    }
+
     await this._bestIndex.append(this._changes.map(IndexNode.encode))
 
     this._bestIndexLength = this._bestIndex.length

--- a/lib/rebase.js
+++ b/lib/rebase.js
@@ -2,9 +2,7 @@ const debounce = require('debounceify')
 const safetyCatch = require('safety-catch')
 
 const { IndexNode } = require('./nodes')
-
 const promises = Symbol.for('hypercore.promises')
-const INDEX_PROTOCOL = '@autobase/index/v1'
 
 class Rebaser {
   constructor (index) {
@@ -59,6 +57,7 @@ module.exports = class RebasedHypercore {
     this._apply = opts.apply || defaultApply
     this._unwrap = !!opts.unwrap
     this._autocommit = opts.autocommit
+    this._header = opts.header
     this._applying = null
 
     this._bestIndex = null
@@ -227,7 +226,7 @@ module.exports = class RebasedHypercore {
       await this._bestIndex.truncate(this._bestIndex.length - this._lastRebaser.removed)
     }
     if (this._bestIndex.length === 0 && this._changes.length) {
-      this._changes[0].header = { protocol: INDEX_PROTOCOL }
+      this._changes[0].header = this._header
     }
 
     await this._bestIndex.append(this._changes.map(IndexNode.encode))

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "corestore": "next",
     "hyperbee": "^1.5.3",
-    "hypercore": "github:hypercore-protocol/hypercore-next#add-encode-batch",
+    "hypercore": "next",
     "latency-stream": "^1.0.0",
     "random-access-memory": "^3.1.2",
     "standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -18,7 +18,7 @@
   "devDependencies": {
     "corestore": "next",
     "hyperbee": "^1.5.3",
-    "hypercore": "next",
+    "hypercore": "github:hypercore-protocol/hypercore-next#add-encode-batch",
     "latency-stream": "^1.0.0",
     "random-access-memory": "^3.1.2",
     "standard": "^16.0.3",

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   "dependencies": {
     "codecs": "^2.2.0",
     "compact-encoding": "^2.0.0",
+    "compact-encoding-struct": "^1.2.0",
     "debounceify": "^1.0.0",
     "mutexify": "^1.3.1",
     "safety-catch": "^1.0.1",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,6 @@
   "dependencies": {
     "codecs": "^2.2.0",
     "compact-encoding": "^2.0.0",
-    "compact-encoding-struct": "^1.2.0",
     "debounceify": "^1.0.0",
     "mutexify": "^1.3.1",
     "safety-catch": "^1.0.1",

--- a/test/autobee.js
+++ b/test/autobee.js
@@ -44,8 +44,8 @@ test('simple autobee', async t => {
   await writer1.put('a', 'a')
   await writer2.put('b', 'b')
 
-  t.same(firstUser.length, 2)
-  t.same(secondUser.length, 2)
+  t.same(firstUser.length, 1)
+  t.same(secondUser.length, 1)
 
   {
     const node = await writer2.get('a')

--- a/test/basic.js
+++ b/test/basic.js
@@ -310,4 +310,23 @@ test('can parse headers', async t => {
   t.end()
 })
 
+test('close cleans up writer sessions', async t => {
+  const writerA = new Hypercore(ram)
+  const writerB = new Hypercore(ram)
+
+  const base = new Autobase([writerA, writerB])
+  await base.ready()
+
+  t.same(writerA.sessions.length, 2)
+  t.same(writerB.sessions.length, 2)
+
+  await base.close()
+  await base.close()
+
+  t.same(writerA.sessions.length, 1)
+  t.same(writerB.sessions.length, 1)
+
+  t.end()
+})
+
 // TODO: Add a test case that links directly to the links of a previous input node.

--- a/test/basic.js
+++ b/test/basic.js
@@ -287,4 +287,27 @@ test('can append through the local input', async t => {
   t.end()
 })
 
+test('can parse headers', async t => {
+  const output = new Hypercore(ram)
+  const writer = new Hypercore(ram)
+  const notAutobase = new Hypercore(ram)
+  await notAutobase.append(Buffer.from('hello world'))
+
+  const base = new Autobase([writer], {
+    input: writer
+  })
+  await base.ready()
+
+  await base.local.append('a0')
+
+  const index = base.createRebasedIndex(output)
+  await index.update()
+
+  t.true(await Autobase.isAutobase(writer))
+  t.true(await Autobase.isAutobase(output))
+  t.false(await Autobase.isAutobase(notAutobase))
+
+  t.end()
+})
+
 // TODO: Add a test case that links directly to the links of a previous input node.

--- a/test/helpers/index.js
+++ b/test/helpers/index.js
@@ -13,7 +13,7 @@ async function collect (stream, map) {
 async function indexedValues (index) {
   const buf = []
   await index.update()
-  for (let i = index.length - 1; i > 0; i--) {
+  for (let i = index.length - 1; i >= 0; i--) {
     const indexNode = await index.get(i)
     buf.push(indexNode)
   }

--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -142,7 +142,7 @@ test('read stream - resolve hook, resolvable', async t => {
     const output = await collect(base2.createReadStream({
       async resolve (node) {
         t.same(node.id, writerB.key.toString('hex'))
-        t.same(node.clock.get(writerA.key.toString('hex')), 1)
+        t.same(node.clock.get(writerA.key.toString('hex')), 0)
         await base2.addInput(writerA)
         return true
       }
@@ -182,7 +182,7 @@ test('read stream - resolve hook, not resolvable', async t => {
     const output = await collect(base2.createReadStream({
       async resolve (node) {
         t.same(node.id, writerB.key.toString('hex'))
-        t.same(node.clock.get(writerA.key.toString('hex')), 1)
+        t.same(node.clock.get(writerA.key.toString('hex')), 0)
         return false
       }
     }))

--- a/test/rebasing.js
+++ b/test/rebasing.js
@@ -31,7 +31,7 @@ test('simple rebase', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   // Add 3 more records to A -- should switch fork ordering
@@ -45,7 +45,7 @@ test('simple rebase', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b1', 'b0', 'c2', 'c1', 'c0', 'a3', 'a2', 'a1', 'a0']))
     t.same(index.status.added, 9)
     t.same(index.status.removed, 6)
-    t.same(output.length, 10)
+    t.same(output.length, 9)
   }
 
   t.end()
@@ -78,7 +78,7 @@ test('simple rebase with default index', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   // Add 3 more records to A -- should switch fork ordering
@@ -91,7 +91,7 @@ test('simple rebase with default index', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b1', 'b0', 'c2', 'c1', 'c0', 'a3', 'a2', 'a1', 'a0']))
     t.same(index.status.added, 9)
     t.same(index.status.removed, 6)
-    t.same(output.length, 10)
+    t.same(output.length, 9)
   }
 
   t.end()
@@ -121,9 +121,9 @@ test('rebasing with causal writes preserves clock', async t => {
   t.same(indexed.map(v => v.value), bufferize(['c2', 'c1', 'c0', 'b1', 'b0', 'a0']))
   t.same(index.status.added, 6)
   t.same(index.status.removed, 0)
-  t.same(output.length, 7)
+  t.same(output.length, 6)
 
-  for (let i = 2; i < index.length; i++) {
+  for (let i = 1; i < index.length; i++) {
     const prev = await index.get(i - 1)
     const node = await index.get(i)
     t.true(prev.lte(node))
@@ -157,7 +157,7 @@ test('does not over-truncate', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 8)
     t.same(index.status.removed, 0)
-    t.same(output.length, 9)
+    t.same(output.length, 8)
   }
 
   // Add 3 more records to A -- should switch fork ordering (A after C)
@@ -170,7 +170,7 @@ test('does not over-truncate', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b1', 'b0', 'a3', 'a2', 'a1', 'a0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 3)
-    t.same(output.length, 12)
+    t.same(output.length, 11)
   }
 
   // Add 1 more record to B -- should not cause any reordering
@@ -181,7 +181,7 @@ test('does not over-truncate', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b2', 'b1', 'b0', 'a3', 'a2', 'a1', 'a0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 1)
     t.same(index.status.removed, 0)
-    t.same(output.length, 13)
+    t.same(output.length, 12)
   }
 
   t.end()
@@ -212,7 +212,7 @@ test('can cut out a writer', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 8)
     t.same(index.status.removed, 0)
-    t.same(output.length, 9)
+    t.same(output.length, 8)
   }
 
   // Cut out writer B. Should truncate 3
@@ -223,7 +223,7 @@ test('can cut out a writer', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 1) // a0 is reindexed
     t.same(index.status.removed, 3) // a0 is popped and reindexed
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   t.end()
@@ -251,7 +251,7 @@ test('can cut out a writer from the back', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b4', 'b3', 'b2', 'b1', 'b0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   await base.removeInput(writerB)
@@ -261,7 +261,7 @@ test('can cut out a writer from the back', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0']))
     t.same(index.status.added, 1) // a0 is reindexed
     t.same(index.status.removed, 6) // a0 is popped and reindexed
-    t.same(output.length, 2)
+    t.same(output.length, 1)
   }
 
   t.end()
@@ -289,7 +289,7 @@ test('can cut out a writer from the front', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b4', 'b3', 'b2', 'b1', 'b0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   await base.removeInput(writerA)
@@ -299,7 +299,7 @@ test('can cut out a writer from the front', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b4', 'b3', 'b2', 'b1', 'b0']))
     t.same(index.status.added, 0) // a0 is removed
     t.same(index.status.removed, 1) // a0 is removed
-    t.same(output.length, 6)
+    t.same(output.length, 5)
   }
 
   t.end()
@@ -330,7 +330,7 @@ test('can cut out a writer, causal writes', async t => {
     t.same(indexed.map(v => v.value), bufferize(['b1', 'b0', 'a0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 8)
     t.same(index.status.removed, 0)
-    t.same(output.length, 9)
+    t.same(output.length, 8)
   }
 
   // Cut out writer B. Should truncate 3
@@ -341,7 +341,7 @@ test('can cut out a writer, causal writes', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'c4', 'c3', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 0) // b1 and b0 are removed
     t.same(index.status.removed, 2) // b1 and b0 are removed
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   t.end()
@@ -368,7 +368,7 @@ test('can cut out a writer, causal writes interleaved', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a5', 'b4', 'a3', 'b2', 'a1', 'b0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   await base.removeInput(writerB)
@@ -378,7 +378,7 @@ test('can cut out a writer, causal writes interleaved', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a5', 'a3', 'a1']))
     t.same(index.status.added, 3)
     t.same(index.status.removed, 6)
-    t.same(output.length, 4)
+    t.same(output.length, 3)
   }
 
   t.end()
@@ -423,10 +423,10 @@ test('many writers, no causal writes', async t => {
   })
   await index.update()
 
-  for (let i = 1; i < NUM_APPENDS + Math.floor(writers.length / 2) + 1; i++) {
+  for (let i = 0; i < NUM_APPENDS + Math.floor(writers.length / 2); i++) {
     const latestNode = await index.get(i)
     const val = latestNode.toString('utf-8')
-    t.same(val, (await decodedMiddleWriter.get(i - 1)).value.toString('utf-8'))
+    t.same(val, (await decodedMiddleWriter.get(i)).value.toString('utf-8'))
   }
 
   t.end()
@@ -457,7 +457,7 @@ test('double-rebasing is a no-op', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 6)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   {
@@ -465,7 +465,7 @@ test('double-rebasing is a no-op', async t => {
     t.same(indexed.map(v => v.value), bufferize(['a0', 'b1', 'b0', 'c2', 'c1', 'c0']))
     t.same(index.status.added, 0)
     t.same(index.status.removed, 0)
-    t.same(output.length, 7)
+    t.same(output.length, 6)
   }
 
   t.end()
@@ -517,7 +517,7 @@ test('remote rebasing selects longest index', async t => {
     await reader.update()
     t.same(reader.status.added, 0)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   {
@@ -526,7 +526,7 @@ test('remote rebasing selects longest index', async t => {
     await reader.update()
     t.same(reader.status.added, 3)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   {
@@ -535,7 +535,7 @@ test('remote rebasing selects longest index', async t => {
     await reader.update()
     t.same(reader.status.added, 1)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   {
@@ -544,7 +544,7 @@ test('remote rebasing selects longest index', async t => {
     await reader.update()
     t.same(reader.status.added, 0)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   t.end()
@@ -597,7 +597,7 @@ test('can dynamically add/remove default indexes', async function (t) {
     await reader.update()
     t.same(reader.status.added, 6)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   await base2.addDefaultIndex(index1)
@@ -607,7 +607,7 @@ test('can dynamically add/remove default indexes', async function (t) {
     await reader.update()
     t.same(reader.status.added, 3)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   await base2.addDefaultIndex(index2)
@@ -617,7 +617,7 @@ test('can dynamically add/remove default indexes', async function (t) {
     await reader.update()
     t.same(reader.status.added, 1)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   await base2.addDefaultIndex(index3)
@@ -628,7 +628,7 @@ test('can dynamically add/remove default indexes', async function (t) {
     await reader.update()
     t.same(reader.status.added, 0)
     t.same(reader.status.removed, 0)
-    t.same(reader.length, 7)
+    t.same(reader.length, 6)
   }
 
   t.end()

--- a/test/rebasing.js
+++ b/test/rebasing.js
@@ -426,7 +426,7 @@ test('many writers, no causal writes', async t => {
   for (let i = 1; i < NUM_APPENDS + Math.floor(writers.length / 2) + 1; i++) {
     const latestNode = await index.get(i)
     const val = latestNode.toString('utf-8')
-    t.same(val, (await decodedMiddleWriter.get(i)).value.toString('utf-8'))
+    t.same(val, (await decodedMiddleWriter.get(i - 1)).value.toString('utf-8'))
   }
 
   t.end()

--- a/test/rebasing.js
+++ b/test/rebasing.js
@@ -357,9 +357,9 @@ test('can cut out a writer, causal writes interleaved', async t => {
 
   for (let i = 0; i < 6; i++) {
     if (i % 2) {
-      await base.append(`a${i}`, writerA)
+      await base.append(`a${i}`, await base.latest(), writerA)
     } else {
-      await base.append(`b${i}`, writerB)
+      await base.append(`b${i}`, await base.latest(), writerB)
     }
   }
 


### PR DESCRIPTION
This PR bundles together two changes:
1. `base.append(value)` will no longer compute the latest clock (potentially causing network I/O). Instead, a private property `base._clock` will be updated whenever any of the inputs are appended to, and `base.append` will use this clock. This clock is exposed through a method (`base.clock()`), to indicate that the returned clock is immutable.
2. Autobase inputs and rebased indexes no longer insert header blocks. Instead, the `InputNode` and `IndexNode` encodings now include optional `header` fields which will only be non-null in the first blocks.

To detect if a Hypercore is an Autobase input or index, I've added the `await Autobase.isAutobase(core)` static method, which will attempt to read/parse the header from block 0 of `core`.