### PR TITLE
Added more read stream options

### DIFF
--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -272,6 +272,43 @@ test('read stream - resume from checkpoint', async t => {
   t.end()
 })
 
+test('read stream - { wait: false } will not download remote blocks', async t => {
+  const writerA = new Hypercore(ram)
+  await writerA.ready()
+  const writerB = new Hypercore(ram)
+  const remoteWriterA = new Hypercore(ram, writerA.key)
+
+  const base1 = new Autobase([writerA], { input: writerA })
+  const base2 = new Autobase([remoteWriterA, writerB], { input: writerB })
+
+  const s1 = writerA.replicate(true, { live: true })
+  const s2 = remoteWriterA.replicate(false, { live: true })
+  s1.pipe(s2).pipe(s1)
+
+  await base1.append('a0')
+  await base2.append('b0')
+  await base1.append('a1')
+  await base2.append('b1')
+
+  await remoteWriterA.get(0) // Download the first block
+
+  {
+    // With wait: false, the read stream should only yield locally-available nodes
+    const output = await collect(base2.createReadStream({ wait: false }))
+    t.same(output.length, 3)
+    validateReadOrder(t, output)
+  }
+
+  {
+    // The normal read stream should download all blocks.
+    const output = await collect(base2.createReadStream())
+    t.same(output.length, 4)
+    validateReadOrder(t, output)
+  }
+
+  t.end()
+})
+
 function validateReadOrder (t, nodes) {
   for (let i = 0; i < nodes.length - 2; i++) {
     t.true(lteOrIndependent(nodes[i], nodes[i + 1]))


### PR DESCRIPTION
This PR adds and modifies a few of the options to `base.createReadStream()`:
1. `opts.resolve` => `opts.onresolve` because it's a callback
2. `opts.wait` => `opts.onwait` because it's a callback
3. `opts.wait` is now a Boolean with the same semantics as the Hypercore `get` option
4. `opts.checkpoint` is an opaque value that can be accessed on the stream (`stream.checkpoint`) and subsequently passed into a new stream as an option. It will cause the new stream to resume where the previous one left off.