### PR TITLE
Add tail option to createReadStream

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ Options include:
 ```js
 {
   live: false, // Enable live mode (the stream will continuously yield new nodes)
+  tail: false, // When in live mode, start at the latest clock instead of the earliest
   map: (node) => node // A sync map function,
   checkpoint: null, // Resume from where a previous read stream left off (`readStream.checkpoint`)
   wait: true, // If false, the read stream will only yield previously-downloaded blocks.

--- a/index.js
+++ b/index.js
@@ -364,7 +364,7 @@ module.exports = class Autobase {
 
         let pos = positionsByKey.get(key)
         if (pos === undefined) {
-          pos = 0
+          pos = opts.tail === true ? input.length : 0
           positionsByKey.set(key, pos)
         }
 

--- a/test/read-stream.js
+++ b/test/read-stream.js
@@ -369,7 +369,6 @@ test('read stream - tail option will start at the latest clock', async t => {
     })
   })
 
-  // Add 3 more records to A -- not causally linked to B or C
   for (let i = 1; i < 4; i++) {
     await base.append(`a${i}`, await base.latest(writerA), writerA)
   }


### PR DESCRIPTION
When using `createReadStream` in live mode, it's often useful to start the read stream at the latest clock (instead of yielding the complete Autobase).

This PR adds the `tail` option to support this.