### PR TITLE
Fix _onOutputTruncated

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ module.exports = class Autobase extends EventEmitter {
 
     const self = this
     this._onappend = this._onInputAppended.bind(this)
-    this._ontruncate = function (length, forkId) {
-      self._onOutputTruncated(this, length, forkId)
+    this._ontruncate = function (length) {
+      self._onOutputTruncated(this, length)
     }
 
     this._opening = this._open()
@@ -102,10 +102,10 @@ module.exports = class Autobase extends EventEmitter {
     this._outputsByKey.delete(id)
   }
 
-  _onOutputTruncated (output, length, forkId) {
+  _onOutputTruncated (output, length) {
     if (!this.view) return
 
-    this.view._onOutputTruncated(output, length, forkId)
+    this.view._onOutputTruncated(output, length)
   }
 
   _onInputAppended () {

--- a/index.js
+++ b/index.js
@@ -103,7 +103,7 @@ module.exports = class Autobase extends EventEmitter {
   }
 
   _onOutputTruncated (output, length, forkId) {
-    if(!this.view) return
+    if (!this.view) return
 
     this.view._onOutputTruncated(output, length, forkId)
   }

--- a/index.js
+++ b/index.js
@@ -103,9 +103,9 @@ module.exports = class Autobase extends EventEmitter {
   }
 
   _onOutputTruncated (output, length, forkId) {
-    for (const view of this._views) {
-      view._onOutputTruncated(output, length, forkId)
-    }
+    if(!this.view) return
+
+    this.view._onOutputTruncated(output, length, forkId)
   }
 
   _onInputAppended () {

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -217,6 +217,7 @@ module.exports = class LinearizedView extends EventEmitter {
   }
 
   _onOutputTruncated (output, length, forkId) {
+    // XXX: is forkId needed here ?
     const linearizer = this._linearizersByOutput.get(output)
     if (!linearizer) return
     linearizer._onTruncate(length)

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -219,7 +219,7 @@ module.exports = class LinearizedView extends EventEmitter {
   _onOutputTruncated (output, length, forkId) {
     const linearizer = this._linearizersByOutput.get(output)
     if (!linearizer) return
-    linearizer._onOutputTruncated(length, forkId)
+    linearizer._onTruncate(length)
   }
 
   _refreshLinearizers () {

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -216,8 +216,7 @@ module.exports = class LinearizedView extends EventEmitter {
     return 0
   }
 
-  _onOutputTruncated (output, length, forkId) {
-    // XXX: is forkId needed here ?
+  _onOutputTruncated (output, length) {
     const linearizer = this._linearizersByOutput.get(output)
     if (!linearizer) return
     linearizer._onTruncate(length)


### PR DESCRIPTION
- adapted for matching the new 1 view model.
- fixed LinearizedView call on output Linearizer (leaved the forkId parameted, but seems to not be usefull here)