### PR TITLE
[WIP] Improved snapshot management

### DIFF
--- a/examples/autobee-with-resolution.js
+++ b/examples/autobee-with-resolution.js
@@ -16,10 +16,12 @@ module.exports = class Autobee {
     this.autobase.start({
       unwrap: true,
       apply: applyAutobeeBatch,
-      view: core => new Hyperbee(core.unwrap(), {
-        ...opts,
-        extension: false
-      })
+      view: core => {
+        return new Hyperbee(core.unwrap(), {
+          ...opts,
+          extension: false
+        })
+      }
     })
     this.bee = this.autobase.view
   }

--- a/index.js
+++ b/index.js
@@ -7,7 +7,7 @@ const mutexify = require('mutexify/promise')
 const c = require('compact-encoding')
 const b = require('b4a')
 
-const BranchSnapshot = require('./lib/linearize')
+const LinearizedCore = require('./lib/linearize')
 const MemberBatch = require('./lib/batch')
 const KeyCompressor = require('./lib/compression')
 const Output = require('./lib/output')
@@ -205,14 +205,14 @@ module.exports = class Autobase extends EventEmitter {
 
   start ({ view, apply, unwrap } = {}) {
     if (this.view) throw new Error('Start must only be called once')
-    const snapshot = new BranchSnapshot(this, {
+    const core = new LinearizedCore(this, {
       header: { protocol: OUTPUT_PROTOCOL },
       view,
       apply,
       unwrap
     })
-    const core = snapshot.session()
-    this.view = view ? view(core) : core
+    const session = core.session()
+    this.view = view ? view(session) : session
   }
 
   async heads (clock) {

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -9,8 +9,6 @@ const promises = Symbol.for('hypercore.promises')
 
 const MAX_GET_RETRIES = 32
 
-global.outputBranches = []
-
 class AppliedBranch {
   constructor (autobase, nodes, oldLength, oldClock) {
     this.autobase = autobase
@@ -76,8 +74,6 @@ class AppliedBranch {
 
 class OutputsBranch {
   constructor (cores, opts = {}) {
-    global.outputBranches.push(this)
-    this.__debugStack = (new Error()).stack
     this.cores = cores
     this.heads = opts.heads || new Map()
 
@@ -238,7 +234,6 @@ class OutputsBranch {
   async close () {
     await this._opening
     if (this.snapshots) await Promise.all(this.snapshots.map(s => s.close()))
-    global.outputBranches.splice(global.outputBranches.indexOf(this), 1)
   }
 }
 
@@ -518,8 +513,8 @@ class LinearizedCore {
     // If we're building a local index, and the clock is the same, no work is needed.
     // (If we're not building a local index, the state of the remote outputs might have changed, so must update)
     const clock = await this.autobase.latest()
+
     if (this.autobase.localOutput && this.lastUpdate && eq(clock, this.lastUpdate.clock)) {
-      // No work to do so short-cicruit
       this.status = { appended: 0, truncated: 0 }
       return
     }
@@ -533,7 +528,7 @@ class LinearizedCore {
     }
 
     // Next perform the update
-    return this._rebuild(clock)
+    await this._rebuild(clock)
   }
 
   async updateSession (session) {
@@ -542,6 +537,9 @@ class LinearizedCore {
     await this.root.update()
 
     migrateSession(this, this.root, session)
+
+    if (this.root.status.truncated) session.emit('truncate', this.root.lastUpdate.length - this.root.status.truncated)
+    if (this.root.status.appended) session.emit('append')
 
     if (!this._sessions.length) await this._close()
   }
@@ -644,6 +642,8 @@ class LinearizedCoreSession extends EventEmitter {
     this._pinned = opts.pin === true
     this._snapshotted = opts.snapshot === true
     this._sessionIdx = -1 // Set in BranchSnapshot.session
+
+    this._debugStack = (new Error()).stack
 
     this._snapshot = null
     this._snapshotIdx = -1

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -653,10 +653,6 @@ class LinearizedCoreSession extends EventEmitter {
       req.cancel()
     }
     this._activeRequests = []
-    if (this._snapshotIdx !== -1) {
-      this._snapshot._snapshotSessions.splice(this._snapshotIdx, 1)
-      return
-    }
     return this._core.closeSession(this)
   }
 

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -525,7 +525,7 @@ class LinearizedCore {
       head._sessionIdx = session._sessionIdx
     }
 
-    session._sessionIdx = rootClone._sessions.push(session)
+    session._sessionIdx = rootClone._sessions.push(session) - 1
     session._core = rootClone
     if (session._snapshotSessions.length) {
       for (const s of session._snapshotSessions) {
@@ -636,7 +636,7 @@ class LinearizedCoreSession extends EventEmitter {
     this._sessionIdx = null // Set in BranchSnapshot.session
 
     this._snapshot = null
-    this._snapshotIdx = null
+    this._snapshotIdx = -1
     this._snapshotSessions = []
 
     this.ready = () => this.open()
@@ -710,7 +710,7 @@ class LinearizedCoreSession extends EventEmitter {
     if (this._snapshotted) {
       // If a session is made on a snapshot, it's always bound to that snapshot
       const session = new LinearizedCoreSession(this._core, opts)
-      session._snapshotIdx = this._snapshotSessions.push(session)
+      session._snapshotIdx = this._snapshotSessions.push(session) - 1
       session._snapshot = this
       return session
     }

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -653,6 +653,10 @@ class LinearizedCoreSession extends EventEmitter {
       req.cancel()
     }
     this._activeRequests = []
+    if (this._snapshotIdx !== -1) {
+      this._snapshot._snapshotSessions.splice(this._snapshotIdx, 1)
+      return
+    }
     return this._core.closeSession(this)
   }
 

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -518,7 +518,11 @@ class LinearizedCore {
     // If the session is a snapshot and this LinearizedCore is not the root, migrate the session to a clone of the root.
     await this.root.update()
     const rootClone = this.root.clone()
-    this._sessions.splice(session._sessionIdx, 1)
+
+    const head = this._sessions.pop()
+    this._sessions[session._sessionIdx] = head
+    head._sessionIdx = session._sessionIdx
+
     session._sessionIdx = rootClone._sessions.push(session)
     session._core = rootClone
     if (session._snapshotSessions.length) {
@@ -576,7 +580,9 @@ class LinearizedCore {
   }
 
   closeSession (session) {
-    this._sessions.splice(session._sessionIdx, 1)
+    const head = this._sessions.pop()
+    this._sessions[session._sessionIdx] = head
+    head._sessionIdx = session._sessionIdx
     if (this._sessions.length) return
     return this._close()
   }

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -376,10 +376,11 @@ class Update {
   }
 }
 
-class BranchSnapshot {
+class LinearizedCore {
   constructor (autobase, opts = {}) {
     this.autobase = autobase
 
+    this.root = opts.root || this
     this.nodes = opts.nodes || []
     this.header = opts.header
     this.applyFunction = opts.apply || defaultApply
@@ -389,16 +390,18 @@ class BranchSnapshot {
 
     this.lastUpdate = opts.lastUpdate
 
-    this.status = opts.status || null
+    this.status = opts.status || { appended: 0, truncated: 0 }
     this.length = opts.length || 0
 
     this._writable = opts.writable !== false
     this._applying = null
     this._sessions = []
 
-    this.__debugId = Math.floor(Math.random() * 1000)
-
     this.update = debounceify(this._update.bind(this))
+  }
+
+  get isRoot () {
+    return this.root === this
   }
 
   async _applyPending (pending) {
@@ -408,6 +411,11 @@ class BranchSnapshot {
       batch.push(node)
       if (node.batch[1] > 0) continue
       this._applying = node
+
+      if (!this.view) {
+        const session = this.session({ pin: true })
+        this.view = this.viewFunction ? this.viewFunction(session) : session
+      }
 
       const inputNode = await this.autobase._getInputNode(node.change, node.seq)
       const clocks = {
@@ -472,11 +480,6 @@ class BranchSnapshot {
     this.length = this.status.length
     this.nodes = this.status.nodes
 
-    if (!this.view) {
-      const session = this.session({ pin: true })
-      this.view = this.viewFunction ? this.viewFunction(session) : session
-    }
-
     try {
       await this._applyPending(this.status.pending)
     } catch (err) {
@@ -508,6 +511,22 @@ class BranchSnapshot {
 
   async _update () {
     return this._rebuild(await this.autobase.latest())
+  }
+
+  async updateSession (session) {
+    if (this.isRoot || !session._snapshotted) return this.update()
+    // If the session is a snapshot and this LinearizedCore is not the root, migrate the session to a clone of the root.
+    await this.root.update()
+    const rootClone = this.root.clone()
+    this._sessions.splice(session._sessionIdx, 1)
+    session._sessionIdx = rootClone._sessions.push(session)
+    session._core = rootClone
+    if (session._snapshotSessions.length) {
+      for (const s of session._snapshotSessions) {
+        s._core = rootClone
+      }
+    }
+    if (!this._sessions.length) await this._close()
   }
 
   _get (seq, opts) {
@@ -563,14 +582,16 @@ class BranchSnapshot {
   }
 
   session (opts = {}) {
-    const session = new LinearizedCore(this, opts)
-    session._sessionIdx = this._sessions.push(session) - 1
+    const core = opts.snapshot ? this.clone() : this
+    const session = new LinearizedCoreSession(core, opts)
+    session._sessionIdx = core._sessions.push(session) - 1
     return session
   }
 
   clone (opts) {
-    return new BranchSnapshot(this.autobase, {
+    return new LinearizedCore(this.autobase, {
       ...opts,
+      root: this.root,
       nodes: [...this.nodes], // Must make a copy of the nodes here as they are mutated in-place during updates
       lastUpdate: this.lastUpdate && this.lastUpdate.clone(),
       header: this.header,
@@ -582,8 +603,8 @@ class BranchSnapshot {
   }
 }
 
-class LinearizedCore extends EventEmitter {
-  constructor (snapshot, opts = {}) {
+class LinearizedCoreSession extends EventEmitter {
+  constructor (core, opts = {}) {
     super()
     this[promises] = true
     this.byteLength = 0
@@ -595,13 +616,18 @@ class LinearizedCore extends EventEmitter {
     this._opening = null
     this._closing = null
 
+    this._core = core
     this._activeRequests = []
     this._checkout = opts.checkout || null
     this._clock = opts.clock || null
     this._unwrap = opts.unwrap === true
     this._pinned = opts.pin === true
-    this._snapshot = snapshot
+    this._snapshotted = opts.snapshot === true
     this._sessionIdx = null // Set in BranchSnapshot.session
+
+    this._snapshot = null
+    this._snapshotIdx = null
+    this._snapshotSessions = []
 
     this.ready = () => this.open()
   }
@@ -617,7 +643,11 @@ class LinearizedCore extends EventEmitter {
       req.cancel()
     }
     this._activeRequests = []
-    return this._snapshot.closeSession(this)
+    if (this._snapshotIdx) {
+      this._snapshot._snapshotSessions.splice(this._snapshotIdx, 1)
+      return
+    }
+    return this._core.closeSession(this)
   }
 
   open () {
@@ -634,40 +664,28 @@ class LinearizedCore extends EventEmitter {
     return this._closing
   }
 
-  // LinearizedCore API
+  // LinearizedCoreSession API
 
   get view () {
-    return this._snapshot.view
+    return this._core.view
   }
 
   get status () {
-    return this._snapshot.status
+    return this._core.status
   }
 
   unwrap () {
-    return this.session({ ...this.opts, unwrap: true })
+    return this.session({ unwrap: true })
   }
 
   wrap () {
-    return this.session({ ...this.opts, unwrap: false })
+    return this.session({ unwrap: false })
   }
 
   // Hypercore API
 
   get length () {
-    return this._snapshot.length
-  }
-
-  session (opts = {}) {
-    if (this._pinned || (!opts.snapshot && !opts.checkout)) return this._snapshot.session({ ...this.opts, ...opts })
-    if (opts.snapshot) {
-      // If we're creating a new snapshot, then it must be given a new underlying BranchSnapshot
-      const branch = this._snapshot.clone({ writable: false })
-      return branch.session({ ...this.opts, ...opts })
-    }
-    if (opts.checkout) {
-      throw new Error('Checkout not yet implemented')
-    }
+    return this._core.length
   }
 
   snapshot (opts) {
@@ -678,25 +696,35 @@ class LinearizedCore extends EventEmitter {
     return this.session({ checkout: clock })
   }
 
+  session (opts) {
+    if (this._snapshotted) {
+      // If a session is made on a snapshot, it's always bound to that snapshot
+      const session = new LinearizedCoreSession(this._core, opts)
+      session._snapshotIdx = this._snapshotSessions.push(session)
+      session._snapshot = this
+      return session
+    }
+    return this._core.session({ ...this.opts, ...opts })
+  }
+
   update () {
-    if (this._checkout) return
-    return this._snapshot.update()
+    return this._core.updateSession(this)
   }
 
   async append (blocks) {
     // Must only be called from within an apply function
-    return this._snapshot.append(blocks)
+    return this._core.append(blocks)
   }
 
   async get (seq, opts = {}) {
-    let block = await this._snapshot.get(seq, { ...opts, active: this._activeRequests })
+    let block = await this._core.get(seq, { ...opts, active: this._activeRequests })
     if (!block) return null
     if (this._unwrap) block = block.value
     return opts.valueEncoding ? opts.valueEncoding.decode(block) : block
   }
 }
 
-module.exports = BranchSnapshot
+module.exports = LinearizedCore
 
 function defaultApply (core, batch, clock, change) {
   return core.append(batch.map(b => b.value))

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -654,7 +654,11 @@ class LinearizedCoreSession extends EventEmitter {
     }
     this._activeRequests = []
     if (this._snapshotIdx !== -1) {
-      this._snapshot._snapshotSessions.splice(this._snapshotIdx, 1)
+      const head = this._snapshot._snapshotSessions.pop()
+      if (head !== this) {
+        this._snapshot._snapshotSessions[this._snapshotIdx] = head
+        head._snapshotIdx = this._snapshotIdx
+      }
       return
     }
     return this._core.closeSession(this)

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -9,6 +9,8 @@ const promises = Symbol.for('hypercore.promises')
 
 const MAX_GET_RETRIES = 32
 
+global.outputBranches = []
+
 class AppliedBranch {
   constructor (autobase, nodes, oldLength, oldClock) {
     this.autobase = autobase
@@ -74,6 +76,8 @@ class AppliedBranch {
 
 class OutputsBranch {
   constructor (cores, opts = {}) {
+    global.outputBranches.push(this)
+    this.__debugStack = (new Error()).stack
     this.cores = cores
     this.heads = opts.heads || new Map()
 
@@ -233,8 +237,8 @@ class OutputsBranch {
 
   async close () {
     await this._opening
-    if (!this.snapshots) return
-    return Promise.all(this.snapshots.map(s => s.close()))
+    if (this.snapshots) await Promise.all(this.snapshots.map(s => s.close()))
+    global.outputBranches.splice(global.outputBranches.indexOf(this), 1)
   }
 }
 
@@ -510,28 +514,35 @@ class LinearizedCore {
   }
 
   async _update () {
-    return this._rebuild(await this.autobase.latest())
+    // First check if any work needs to be done
+    // If we're building a local index, and the clock is the same, no work is needed.
+    // (If we're not building a local index, the state of the remote outputs might have changed, so must update)
+    const clock = await this.autobase.latest()
+    if (this.autobase.localOutput && this.lastUpdate && eq(clock, this.lastUpdate.clock)) {
+      // No work to do so short-cicruit
+      this.status = { appended: 0, truncated: 0 }
+      return
+    }
+
+    // Next check if any snapshot sessions need to be migrated to a root clone before the update
+    if (this.isRoot) {
+      const snapshots = this._sessions.filter(s => s._snapshotted)
+      for (const snapshot of snapshots) {
+        migrateSession(this, this.clone(), snapshot)
+      }
+    }
+
+    // Next perform the update
+    return this._rebuild(clock)
   }
 
   async updateSession (session) {
-    if (this.isRoot || !session._snapshotted) return this.update()
-    // If the session is a snapshot and this LinearizedCore is not the root, migrate the session to a clone of the root.
+    if (!session._snapshotted) return this.update()
+    // If the session is a snapshot and this LinearizedCore is not the root, migrate the session to the root and update the root.
     await this.root.update()
-    const rootClone = this.root.clone()
 
-    const head = this._sessions.pop()
-    if (head !== session) {
-      this._sessions[session._sessionIdx] = head
-      head._sessionIdx = session._sessionIdx
-    }
+    migrateSession(this, this.root, session)
 
-    session._sessionIdx = rootClone._sessions.push(session) - 1
-    session._core = rootClone
-    if (session._snapshotSessions.length) {
-      for (const s of session._snapshotSessions) {
-        s._core = rootClone
-      }
-    }
     if (!this._sessions.length) await this._close()
   }
 
@@ -592,9 +603,8 @@ class LinearizedCore {
   }
 
   session (opts = {}) {
-    const core = opts.snapshot ? this.clone() : this
-    const session = new LinearizedCoreSession(core, opts)
-    session._sessionIdx = core._sessions.push(session) - 1
+    const session = new LinearizedCoreSession(this, opts)
+    session._sessionIdx = this._sessions.push(session) - 1
     return session
   }
 
@@ -742,4 +752,20 @@ module.exports = LinearizedCore
 
 function defaultApply (core, batch, clock, change) {
   return core.append(batch.map(b => b.value))
+}
+
+function migrateSession (from, to, session) {
+  const head = from._sessions.pop()
+  if (head !== session) {
+    from._sessions[session._sessionIdx] = head
+    head._sessionIdx = session._sessionIdx
+  }
+
+  session._sessionIdx = to._sessions.push(session) - 1
+  session._core = to
+  if (session._snapshotSessions.length) {
+    for (const s of session._snapshotSessions) {
+      s._core = to
+    }
+  }
 }

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -633,7 +633,7 @@ class LinearizedCoreSession extends EventEmitter {
     this._unwrap = opts.unwrap === true
     this._pinned = opts.pin === true
     this._snapshotted = opts.snapshot === true
-    this._sessionIdx = null // Set in BranchSnapshot.session
+    this._sessionIdx = -1 // Set in BranchSnapshot.session
 
     this._snapshot = null
     this._snapshotIdx = -1

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -653,7 +653,7 @@ class LinearizedCoreSession extends EventEmitter {
       req.cancel()
     }
     this._activeRequests = []
-    if (this._snapshotIdx) {
+    if (this._snapshotIdx !== -1) {
       this._snapshot._snapshotSessions.splice(this._snapshotIdx, 1)
       return
     }

--- a/lib/linearize.js
+++ b/lib/linearize.js
@@ -520,8 +520,10 @@ class LinearizedCore {
     const rootClone = this.root.clone()
 
     const head = this._sessions.pop()
-    this._sessions[session._sessionIdx] = head
-    head._sessionIdx = session._sessionIdx
+    if (head !== session) {
+      this._sessions[session._sessionIdx] = head
+      head._sessionIdx = session._sessionIdx
+    }
 
     session._sessionIdx = rootClone._sessions.push(session)
     session._core = rootClone
@@ -581,8 +583,10 @@ class LinearizedCore {
 
   closeSession (session) {
     const head = this._sessions.pop()
-    this._sessions[session._sessionIdx] = head
-    head._sessionIdx = session._sessionIdx
+    if (head !== session) {
+      this._sessions[session._sessionIdx] = head
+      head._sessionIdx = session._sessionIdx
+    }
     if (this._sessions.length) return
     return this._close()
   }

--- a/test/local-linearizing.js
+++ b/test/local-linearizing.js
@@ -530,7 +530,7 @@ test('local linearizing - can dynamically add/remove default outputs', async t =
   await base4.addOutput(output3)
 
   await base4.view.update()
-  t.same(base4.view.status.nodes.length, 0) // Should switch to output3
+  t.same(base4.view._core.nodes.length, 0) // Should switch to output3
   t.same(base4.view.status.appended, 0)
   t.same(base4.view.status.truncated, 0)
   t.same(base4.view.length, 6)

--- a/test/snapshotting.js
+++ b/test/snapshotting.js
@@ -96,3 +96,41 @@ test('snapshotting - snapshot updates are locked', async t => {
 
   t.end()
 })
+
+test('snapshotting - basic snapshot close', async t => {
+  const output = new Hypercore(ram)
+  const writerA = new Hypercore(ram)
+  const writerB = new Hypercore(ram)
+  const writerC = new Hypercore(ram)
+
+  const base = new Autobase({
+    inputs: [writerA, writerB, writerC],
+    localOutput: output,
+    autostart: true
+  })
+
+  for (let i = 0; i < 1; i++) {
+    await base.append(`a${i}`, [], writerA)
+  }
+  for (let i = 0; i < 2; i++) {
+    await base.append(`b${i}`, [], writerB)
+  }
+  for (let i = 0; i < 3; i++) {
+    await base.append(`c${i}`, [], writerC)
+  }
+
+  const s1 = base.view.snapshot()
+  const s2 = base.view.snapshot()
+  const s3 = base.view.session()
+
+  console.log('base.view core:', base.view._core._sessions.length)
+  console.log('s1 core:', s1._core._sessions.length)
+  console.log('s2 core:', s2._core._sessions.length)
+
+  t.same(s1._sessionIdx, 0)
+  t.same(s2._sessionIdx, 0)
+  t.same(s3._sessionIdx, 1)
+  t.same(base.view._sessionIdx, 0)
+
+  t.end()
+})


### PR DESCRIPTION
With this change, there's a single eagerly-updating snapshot (`base.view`) and whenever any additional snapshot is updated, it's migrated over to `base.view`'s internal state (very cheap).

Ignore the test updates for now.