### PR TITLE
Update random-access-memory dep version to add `.truncate()` support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "hyperbee": "^2.0.0",
     "hypercore": "^10.0.0",
     "latency-stream": "^1.0.0",
-    "random-access-memory": "^3.1.2",
+    "random-access-memory": "^5.0.1",
     "standard": "^16.0.3",
     "tape": "^5.1.0"
   },


### PR DESCRIPTION
This fixes the majority of the tests. The only test that doesn't work for me is `manually specifying clocks, unavailable blocks` in `common/basic.js` which looks WIP as it's the only test that uses `console.log`.